### PR TITLE
Fixed dependencies to Python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-nose
+nose==0.11.4
 http://darcs.idyll.org/~t/projects/figleaf-0.6.1.tar.gz
-http://darcs.idyll.org/~t/projects/pinocchio-latest.tar.gz
+https://github.com/unpluggd/pinocchio/tarball/0.2#egg=pinocchio-0.2


### PR DESCRIPTION
Dude, the dependencies to run specloud with Python 2.7 were broken.

I fixed this and I'm working to run it with Python 3.

I'll send you a Pull Request again as soon as possible.

[]'s
